### PR TITLE
Create a standard organization when registering a new user

### DIFF
--- a/lib/coqueiro/accounts/organization_membership.ex
+++ b/lib/coqueiro/accounts/organization_membership.ex
@@ -10,11 +10,10 @@ defmodule Coqueiro.Accounts.OrganizationMembership do
   end
 
   @doc false
-  def changeset(organization_membership, attrs) do
-    organization_membership
-    |> cast(attrs, [])
-    |> validate_required([])
-
-    # |> put_change(:user_id, user_scope.user.id)
+  def changeset(membership, attrs) do
+    membership
+    |> cast(attrs, [:user_id, :organization_id])
+    |> validate_required([:user_id, :organization_id])
+    |> unique_constraint([:user_id, :organization_id])
   end
 end

--- a/lib/coqueiro_web/live/user_live/registration.ex
+++ b/lib/coqueiro_web/live/user_live/registration.ex
@@ -50,7 +50,7 @@ defmodule CoqueiroWeb.UserLive.Registration do
   end
 
   def handle_event("save", %{"user" => user_params}, socket) do
-    case Accounts.register_user(user_params) do
+    case Accounts.register_user_with_organization(user_params) do
       {:ok, user} ->
         {:ok, _} =
           Accounts.deliver_login_instructions(


### PR DESCRIPTION
Where registering a new user, it creates a organization and its membership.

The newly created user:

```
sqlite> select * from users;
id  email            hashed_password  confirmed_at  inserted_at           updated_at
--  ---------------  ---------------  ------------  --------------------  --------------------
1   dhony@gmail.com                                 2025-06-01T20:48:15Z  2025-06-01T20:48:15Z
```

It creates a standard organization for this user. It is called Personal and it receives the email as the organization `slug`.

```
sqlite> select * from organizations;
id  name      slug             active  inserted_at           updated_at
--  --------  ---------------  ------  --------------------  --------------------
1   Personel  dhony@gmail.com  1       2025-06-01T20:48:15Z  2025-06-01T20:48:15Z
```

And also, create the membership between the newly created user and its organization.

```
sqlite> select * from organization_memberships;
id  user_id  organization_id  inserted_at           updated_at
--  -------  ---------------  --------------------  --------------------
1   1        1                2025-06-01T20:48:15Z  2025-06-01T20:48:15Z
```

Here is the Organization listed under the logged user.

<img width="742" alt="user_and_its_default_organization" src="https://github.com/user-attachments/assets/44931540-06d8-4f1d-8724-1f52c17aa02f" />

And all the Posts of the User under its Organization. See the Scopes `%User{}`, `%Organization{}` and `%Membership{}` properly set.

<img width="854" alt="user_and_its_posts_under_default_org" src="https://github.com/user-attachments/assets/0b89af82-cf5a-4107-8014-bb8e3c68d72d" />


