### PR TITLE
Add column role to the membership

### DIFF
--- a/lib/coqueiro/accounts.ex
+++ b/lib/coqueiro/accounts.ex
@@ -109,7 +109,8 @@ defmodule Coqueiro.Accounts do
       {:ok, _membership} =
         create_membership(%{
           user_id: user.id,
-          organization_id: organization.id
+          organization_id: organization.id,
+          role: "admin"
         })
 
       user

--- a/lib/coqueiro/accounts/organization_membership.ex
+++ b/lib/coqueiro/accounts/organization_membership.ex
@@ -2,7 +2,11 @@ defmodule Coqueiro.Accounts.OrganizationMembership do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @roles ~w(admin manager member)a
+
   schema "organization_memberships" do
+    field :role, :string, default: "member"
+
     belongs_to :user, Riacho.Accounts.User
     belongs_to :organization, Riacho.Accounts.Organization
 
@@ -12,8 +16,9 @@ defmodule Coqueiro.Accounts.OrganizationMembership do
   @doc false
   def changeset(membership, attrs) do
     membership
-    |> cast(attrs, [:user_id, :organization_id])
-    |> validate_required([:user_id, :organization_id])
+    |> cast(attrs, [:role, :user_id, :organization_id])
+    |> validate_required([:role, :user_id, :organization_id])
+    |> validate_inclusion(:role, Enum.map(@roles, &Atom.to_string/1))
     |> unique_constraint([:user_id, :organization_id])
   end
 end

--- a/priv/repo/migrations/20250601001531_create_organization_memberships.exs
+++ b/priv/repo/migrations/20250601001531_create_organization_memberships.exs
@@ -5,6 +5,7 @@ defmodule Coqueiro.Repo.Migrations.CreateOrganizationMemberships do
     create table(:organization_memberships) do
       add :user_id, references(:users, on_delete: :nothing)
       add :organization_id, references(:organizations, on_delete: :nothing)
+      add :role, :string, null: false, default: "member"
 
       timestamps(type: :utc_datetime)
     end


### PR DESCRIPTION
Adding column `role` to the `organization_memberships` table. Now when registering a new user, it will get the admin role to the organization membership.

```
sqlite> select * from organization_memberships;
id  user_id  organization_id  role   inserted_at           updated_at
--  -------  ---------------  -----  --------------------  --------------------
1   1        1                admin  2025-06-01T23:27:04Z  2025-06-01T23:27:04Z
```