### PR TITLE
List users who belong to an organization

### DIFF
--- a/lib/coqueiro/accounts.ex
+++ b/lib/coqueiro/accounts.ex
@@ -413,8 +413,8 @@ defmodule Coqueiro.Accounts do
       ** (Ecto.NoResultsError)
 
   """
-  def get_organization!(%Scope{} = _scope, slug) do
-    Repo.get_by!(Organization, slug: slug)
+  def get_organization!(%Scope{} = _scope, id) do
+    Repo.get_by!(Organization, id: id)
   end
 
   def get_organization_by_slug(%Scope{} = _scope, slug) do
@@ -423,6 +423,11 @@ defmodule Coqueiro.Accounts do
 
   def get_organization_by_slug!(%Scope{} = _scope, slug) do
     Repo.get_by!(Organization, slug: slug)
+  end
+
+  def get_organization_with_members!(%Scope{} = scope, id) do
+    Repo.get_by!(Organization, id: id, id: scope.organization.id)
+    |> Repo.preload(organization_memberships: [user: []])
   end
 
   @doc """

--- a/lib/coqueiro/accounts.ex
+++ b/lib/coqueiro/accounts.ex
@@ -415,6 +415,7 @@ defmodule Coqueiro.Accounts do
   """
   def get_organization!(%Scope{} = _scope, id) do
     Repo.get_by!(Organization, id: id)
+    |> Repo.preload(users: [organization_memberships: []])
   end
 
   def get_organization_by_slug(%Scope{} = _scope, slug) do

--- a/lib/coqueiro/accounts/organization.ex
+++ b/lib/coqueiro/accounts/organization.ex
@@ -2,8 +2,6 @@ defmodule Coqueiro.Accounts.Organization do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @derive {Phoenix.Param, key: :slug}
-
   schema "organizations" do
     field :name, :string
     field :slug, :string

--- a/lib/coqueiro_web/live/organization_live/index.ex
+++ b/lib/coqueiro_web/live/organization_live/index.ex
@@ -11,7 +11,7 @@ defmodule CoqueiroWeb.OrganizationLive.Index do
       <.header>
         Listing Organizations
         <:actions>
-          <.button variant="primary" navigate={~p"/organizations/new"}>
+          <.button variant="primary" navigate={~p"/orgs/new"}>
             <.icon name="hero-plus" /> New Organization
           </.button>
         </:actions>
@@ -20,16 +20,16 @@ defmodule CoqueiroWeb.OrganizationLive.Index do
       <.table
         id="organizations"
         rows={@streams.organizations}
-        row_click={fn {_id, organization} -> JS.navigate(~p"/organizations/#{organization}") end}
+        row_click={fn {_id, organization} -> JS.navigate(~p"/orgs/#{organization}") end}
       >
         <:col :let={{_id, organization}} label="Name">{organization.name}</:col>
         <:col :let={{_id, organization}} label="Slug">{organization.slug}</:col>
         <:col :let={{_id, organization}} label="Active">{organization.active}</:col>
         <:action :let={{_id, organization}}>
           <div class="sr-only">
-            <.link navigate={~p"/organizations/#{organization}"}>Show</.link>
+            <.link navigate={~p"/orgs/#{organization}"}>Show</.link>
           </div>
-          <.link navigate={~p"/organizations/#{organization}/edit"}>Edit</.link>
+          <.link navigate={~p"/orgs/#{organization}/edit"}>Edit</.link>
         </:action>
         <:action :let={{id, organization}}>
           <.link

--- a/lib/coqueiro_web/live/organization_live/show.ex
+++ b/lib/coqueiro_web/live/organization_live/show.ex
@@ -26,6 +26,15 @@ defmodule CoqueiroWeb.OrganizationLive.Show do
         <:item title="Slug">{@organization.slug}</:item>
         <:item title="Active">{@organization.active}</:item>
       </.list>
+
+      <p>Users nessa Organization:</p>
+
+      <ul>
+        <%= for user <- @organization.users do %>
+          <li>User Id: {user.id}</li>
+          <li>User Name: {user.email}</li>
+        <% end %>
+      </ul>
     </Layouts.app>
     """
   end

--- a/lib/coqueiro_web/live/organization_live/show.ex
+++ b/lib/coqueiro_web/live/organization_live/show.ex
@@ -12,13 +12,10 @@ defmodule CoqueiroWeb.OrganizationLive.Show do
         Organization {@organization.id}
         <:subtitle>This is a organization record from your database.</:subtitle>
         <:actions>
-          <.button navigate={~p"/organizations"}>
+          <.button navigate={~p"/orgs"}>
             <.icon name="hero-arrow-left" />
           </.button>
-          <.button
-            variant="primary"
-            navigate={~p"/organizations/#{@organization}/edit?return_to=show"}
-          >
+          <.button variant="primary" navigate={~p"/orgs/#{@organization}/edit?return_to=show"}>
             <.icon name="hero-pencil-square" /> Edit organization
           </.button>
         </:actions>
@@ -42,7 +39,10 @@ defmodule CoqueiroWeb.OrganizationLive.Show do
     {:ok,
      socket
      |> assign(:page_title, "Show Organization")
-     |> assign(:organization, Accounts.get_organization!(socket.assigns.current_scope, id))}
+     |> assign(
+       :organization,
+       Accounts.get_organization!(socket.assigns.current_scope, id)
+     )}
   end
 
   @impl true
@@ -60,7 +60,7 @@ defmodule CoqueiroWeb.OrganizationLive.Show do
     {:noreply,
      socket
      |> put_flash(:error, "The current organization was deleted.")
-     |> push_navigate(to: ~p"/organizations")}
+     |> push_navigate(to: ~p"/orgs")}
   end
 
   def handle_info({type, %Coqueiro.Accounts.Organization{}}, socket)

--- a/lib/coqueiro_web/router.ex
+++ b/lib/coqueiro_web/router.ex
@@ -72,15 +72,16 @@ defmodule CoqueiroWeb.Router do
       live "/users/log-in", UserLive.Login, :new
       live "/users/log-in/:token", UserLive.Confirmation, :new
 
-      live "/organizations", OrganizationLive.Index, :index
-      live "/organizations/new", OrganizationLive.Form, :new
-      live "/organizations/:id", OrganizationLive.Show, :show
-      live "/organizations/:id/edit", OrganizationLive.Form, :edit
+      live "/orgs", OrganizationLive.Index, :index
+      live "/orgs/new", OrganizationLive.Form, :new
+      live "/orgs/:id", OrganizationLive.Show, :show
+      live "/orgs/:id/edit", OrganizationLive.Form, :edit
 
-      live "/orgs/:org/posts", PostLive.Index, :index
-      live "/orgs/:org/posts/new", PostLive.Form, :new
-      live "/orgs/:org/posts/:id", PostLive.Show, :show
-      live "/orgs/:org/posts/:id/edit", PostLive.Form, :edit
+      live "/orgs/:id", OrganizationLive.Show, :show
+      live "/orgs/:id/posts", PostLive.Index, :index
+      live "/orgs/:id/posts/new", PostLive.Form, :new
+      live "/orgs/:id/posts/:id", PostLive.Show, :show
+      live "/orgs/:id/posts/:id/edit", PostLive.Form, :edit
     end
 
     post "/users/log-in", UserSessionController, :create

--- a/lib/coqueiro_web/user_auth.ex
+++ b/lib/coqueiro_web/user_auth.ex
@@ -245,10 +245,10 @@ defmodule CoqueiroWeb.UserAuth do
     end
   end
 
-  def on_mount(:assign_org_to_scope, %{"org" => slug}, _session, socket) do
+  def on_mount(:assign_org_to_scope, %{"id" => id}, _session, socket) do
     current_scope = socket.assigns.current_scope
 
-    case Coqueiro.Accounts.get_organization_by_slug!(current_scope, slug) do
+    case Coqueiro.Accounts.get_organization!(current_scope, id) do
       %Coqueiro.Accounts.Organization{} = org ->
         if membership = Coqueiro.Accounts.get_membership(current_scope.user, org) do
           new_scope =
@@ -261,14 +261,14 @@ defmodule CoqueiroWeb.UserAuth do
           {:halt,
            socket
            |> put_flash(:error, "You don't have access to that organization")
-           |> redirect(to: ~p"/organizations")}
+           |> redirect(to: ~p"/orgs")}
         end
 
       _ ->
         {:halt,
          socket
          |> put_flash(:error, "Organization not found")
-         |> redirect(to: ~p"/organizations")}
+         |> redirect(to: ~p"/orgs")}
     end
   end
 
@@ -277,8 +277,8 @@ defmodule CoqueiroWeb.UserAuth do
   def assign_org_to_scope(conn, _opts) do
     current_scope = conn.assigns.current_scope
 
-    if slug = conn.params["org"] do
-      org = Coqueiro.Accounts.get_organization_by_slug!(current_scope, slug)
+    if id = conn.params["org"] do
+      org = Coqueiro.Accounts.get_organization!(current_scope, id)
       assign(conn, :current_scope, Coqueiro.Accounts.Scope.put_organization(current_scope, org))
     else
       conn


### PR DESCRIPTION
For this activity, we added the :preload macro the `get_organization!` function.

```elixir
def get_organization!(%Scope{} = _scope, id) do
    Repo.get_by!(Organization, id: id)
    |> Repo.preload(users: [organization_memberships: []])
end
```

Notice the order: `users: [organization_memberships: []]`

Inspecting the `current_scope` through the `/orgs/:id/`, we can see the `users` node nested to `organization`.

The nesting is `organization` -> `users` -> `organization_memberships`

```elixir
%Coqueiro.Accounts.Scope{
  user: #Coqueiro.Accounts.User<
    __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
    id: 2,
    email: "tamy@gmail.com",
    confirmed_at: ~U[2025-06-02 00:11:23Z],
    authenticated_at: ~U[2025-06-02 00:11:23Z],
    organizations: #Ecto.Association.NotLoaded<association :organizations is not loaded>,
    organization_memberships: #Ecto.Association.NotLoaded<association :organization_memberships is not loaded>,
    inserted_at: ~U[2025-06-02 00:11:17Z],
    updated_at: ~U[2025-06-02 00:11:23Z],
    ...
  >,
  organization: %Coqueiro.Accounts.Organization{
    __meta__: #Ecto.Schema.Metadata<:loaded, "organizations">,
    id: 2,
    name: "Personel",
    slug: "tamy@gmail.com",
    active: true,
    users: [
      #Coqueiro.Accounts.User<
        __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
        id: 2,
        email: "tamy@gmail.com",
        confirmed_at: ~U[2025-06-02 00:11:23Z],
        authenticated_at: nil,
        organizations: #Ecto.Association.NotLoaded<association :organizations is not loaded>,
        organization_memberships: [
          %Coqueiro.Accounts.OrganizationMembership{
            __meta__: #Ecto.Schema.Metadata<:loaded, "organization_memberships">,
            id: 2,
            role: "admin",
            user_id: 2,
            user: #Ecto.Association.NotLoaded<association :user is not loaded>,
            organization_id: 2,
            organization: #Ecto.Association.NotLoaded<association :organization is not loaded>,
            inserted_at: ~U[2025-06-02 00:11:17Z],
            updated_at: ~U[2025-06-02 00:11:17Z]
          }
        ],
        inserted_at: ~U[2025-06-02 00:11:17Z],
        updated_at: ~U[2025-06-02 00:11:23Z],
        ...
      >
    ],
    inserted_at: ~U[2025-06-02 00:11:17Z],
    updated_at: ~U[2025-06-02 00:11:17Z]
  },
  membership: %Coqueiro.Accounts.OrganizationMembership{
    __meta__: #Ecto.Schema.Metadata<:loaded, "organization_memberships">,
    id: 2,
    role: "admin",
    user_id: 2,
    user: #Ecto.Association.NotLoaded<association :user is not loaded>,
    organization_id: 2,
    organization: #Ecto.Association.NotLoaded<association :organization is not loaded>,
    inserted_at: ~U[2025-06-02 00:11:17Z],
    updated_at: ~U[2025-06-02 00:11:17Z]
  }
}
```

We will check later if this order is the appropriate.